### PR TITLE
Fixed PHP 7.4 parenthesis missing notice #6

### DIFF
--- a/views/ip_geoloc_plugin_style.inc
+++ b/views/ip_geoloc_plugin_style.inc
@@ -466,7 +466,7 @@ function _ip_geoloc_plugin_style_diff_color_table_row_form($is_openlayers, $row,
       if (isset($instance['widget']['settings']['size']) && $instance['widget']['settings']['size'] < 15) {
         $instance['widget']['settings']['size'] = 15;
       }
-      $items[0] = empty($differentiator_value) ? array() : is_array($differentiator_value) ? $differentiator_value : array($differentiator_value);
+      $items[0] = empty($differentiator_value) ? array() : (is_array($differentiator_value) ? $differentiator_value : array($differentiator_value));
       if (isset($instance['default_value'])) {
         $items[0] += is_array($instance['default_value']) && !empty($instance['default_value']) ? reset($instance['default_value']) : $instance['default_value'];
       }


### PR DESCRIPTION
Updated views/ip_geoloc_plugin_style.inc to add parenthesis.  The notice goes away after updating.